### PR TITLE
 #9 投稿とユーザーを関連付けし、投稿一覧にユーザー名の表示を追加

### DIFF
--- a/app/Article.php
+++ b/app/Article.php
@@ -7,7 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 class Article extends Model
 {
     protected $guarded = array('id');
-    protected $table = 'Article';
+    protected $table = 'Articles';
 
     // バリデーションルールはフォームリクエストでの定義に変更
     /*
@@ -15,4 +15,14 @@ class Article extends Model
         'body' => 'required',
     );
     */
+
+    /**
+     * リレーションの設定
+     * Usersテーブルと1対多
+     * Articlesテーブルが従テーブル
+     */
+    public function user()
+    {
+        return $this->belongsTo(App\User);
+    }
 }

--- a/app/Http/Controllers/Admin/ArticleController.php
+++ b/app/Http/Controllers/Admin/ArticleController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Admin;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request; // 通常のリクエスト
 use App\Article; // Article Modelを使う
+use Illuminate\Support\Facades\Auth;
 use App\Http\Requests\ArticleRequest; // フォームリクエストを使う
 
 class ArticleController extends Controller
@@ -31,6 +32,10 @@ class ArticleController extends Controller
     } else {
         $articles->image_path = null;
     }
+
+    // ログインユーザー情報を取得する
+    $articles->user_name = Auth::user()->name;
+    // $articles->user_name = 'ユーザー1';
 
     // フォームから送信されてきた_tokenとimageを削除
     unset($form['_token']);

--- a/app/User.php
+++ b/app/User.php
@@ -36,4 +36,14 @@ class User extends Authenticatable
     protected $casts = [
         'email_verified_at' => 'datetime',
     ];
+
+    /**
+     * リレーションの設定
+     * articlesテーブルと1対多
+     * Usersテーブルが主テーブル
+     */
+    public function articles()
+    {
+        return $this->hasMany('App\articles');
+    }
 }

--- a/database/migrations/2020_09_08_132514_rename_article_table_to_articles_table.php
+++ b/database/migrations/2020_09_08_132514_rename_article_table_to_articles_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class RenameArticleTableToArticlesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::rename('article', 'articles');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('article', 'articles');
+    }
+}

--- a/database/migrations/2020_09_08_150333_create_articles_table.php
+++ b/database/migrations/2020_09_08_150333_create_articles_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateArticlesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('articles', function (Blueprint $table) {
+            $table->id();
+            $table->string('body');
+            $table->string('image_path')->nullable();
+            // $table->integer('user_id')->unsigned(); // integerだとaddできない
+            $table->bigInteger('user_id')->unsigned()->nullable();
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade'); // 外部キーを追加
+            $table->string('user_name');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('articles');
+    }
+}

--- a/resources/views/admin/article/index.blade.php
+++ b/resources/views/admin/article/index.blade.php
@@ -37,22 +37,24 @@
           <table class="table table-dark">
             <thead>
               <tr>
-                <th width="10%">ID</th>
+                <th width="10%">投稿ID</th>
+                <th width="10%">投稿者</th>
                 <th width="40%">本文</th>
                 <th width="20%">操作</th>
               </tr>
             </thead>
             <tbody>
-              @foreach ($articles as $article)
+              @foreach ($articles as $post)
                 <tr>
-                  <th>{{ $article->id }}</th>
-                  <td>{{ $article->body }}</td>
+                  <th>{{ $post->id }}</th>
+                  <th>{{ $post->user_name }}</th>
+                  <td>{{ $post->body }}</td>
                   <td>
                     <div>
-                    <a href="{{ action('Admin\ArticleController@edit', ['id' => $article->id]) }}">編集する</a>
+                    <a href="{{ action('Admin\ArticleController@edit', ['id' => $post->id]) }}">編集する</a>
                     </div>
                     <div>
-                    <a href="{{ action('Admin\ArticleController@delete', ['id' => $article->id]) }}">削除する</a>
+                    <a href="{{ action('Admin\ArticleController@delete', ['id' => $post->id]) }}">削除する</a>
                     </div>
                   </td>
                 </tr>


### PR DESCRIPTION
・Migrationでarticlesテーブルのカラム追加とリネームを行い、usersテーブルとの関連付けを行った。
・投稿一覧にユーザー名の表示を追加した。
※ただし、#8のモーダル画面の実装前のデータに対して作業しているので留意。