### PR TITLE
 #42 プロフィール編集のバグを修正&削除機能を追加

### DIFF
--- a/app/Http/Controllers/Admin/ProfileController.php
+++ b/app/Http/Controllers/Admin/ProfileController.php
@@ -16,8 +16,8 @@ class ProfileController extends Controller
     // editアクション
     public function edit(Request $request)
     {
-        // ログインユーザーの情報を取得してViewに渡す
-        $user_data = Auth::user();
+        // Modelからデータを取得する(idで検索)
+        $user_data = User::find($request->id);
         return view('admin.profile.edit', ['user_data' => $user_data]);
     }
 
@@ -63,8 +63,15 @@ class ProfileController extends Controller
         return redirect('admin/users');
     }
 
-    // deleteアクション(未実装)
-    // ログインユーザーを削除してトップ画面にリダイレクトする？
+    // deleteアクション
+    public function delete(Request $request)
+    {
+        // Modelからデータを取得して削除する
+        $user_data = User::find($request->id);
+        $user_data->delete();
+
+        return redirect('admin/users');
+    }
 
     // indexアクション
     public function index(Request $request)

--- a/resources/views/admin/article/index.blade.php
+++ b/resources/views/admin/article/index.blade.php
@@ -104,8 +104,7 @@
                         コメントを追加する
                     </a>
 
-                    {{-- ログインユーザーと一致する場合は編集削除可能にする --}}
-                    {{-- さらに管理ユーザーは全ての投稿の編集削除可能にする --}}
+                    {{-- ログインユーザーと一致する場合または管理ユーザーの場合は編集削除可能 --}}
                     @if ($post->user_id == auth::user()->id || auth::user()->id == 1)
                     <div class="card-link float-right">
                         <a href="{{ action('Admin\ArticleController@edit', ['id' => $post->id]) }}">編集する</a>

--- a/resources/views/admin/profile/index.blade.php
+++ b/resources/views/admin/profile/index.blade.php
@@ -45,7 +45,8 @@
                 {{-- ログインユーザーと一致する場合もしくは管理者の場合は編集リンクを表示 --}}
                 @if ($user->id == auth::user()->id || auth::user()->id == 1)
                 <div class="card-footer">
-                    <a href="{{ action('Admin\ProfileController@edit', ['id' => $user->id]) }}">プロフィールを編集する</a>
+                    <a href="{{ action('Admin\ProfileController@edit', ['id' => $user->id]) }}">編集する</a>
+                    <a href="{{ action('Admin\ProfileController@delete', ['id' => $user->id]) }}">削除する</a>
                 </div>
                 @endif
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -41,6 +41,7 @@ Route::group(['prefix' => 'admin', 'middleware' => 'auth'], function () {
     Route::post('profile/create', 'Admin\ProfileController@create');
     Route::get('profile/edit', 'Admin\ProfileController@edit');
     Route::post('profile/edit', 'Admin\ProfileController@update');
+    Route::get('profile/delete', 'Admin\ProfileController@delete');
     Route::get('users', 'Admin\ProfileController@index');
 });
 


### PR DESCRIPTION
・ユーザー一覧において、管理者権限で他のユーザーのプロフィール編集ボタンを押すと、
　自分のプロフィール画面が表示されるバグを修正。
・ログインユーザーのidでUserモデルを検索していた。
・ProfileControllerでediteアクションを修正することで対応できた。
・その他、プロフィールの削除機能を追加した。(論理削除ではなく完全削除)