### PR TITLE
 #47 コメントや投稿におけるユーザー情報の取得を中心にアップデート

### DIFF
--- a/app/Http/Controllers/Admin/ArticleController.php
+++ b/app/Http/Controllers/Admin/ArticleController.php
@@ -139,15 +139,4 @@ class ArticleController extends Controller
         }
         return view('admin.article.index', ['articles' => $articles, 'search_text' => $search_text]);
     }
-
-    // showアクション
-    public function show(Request $request)
-    {
-        // 投稿idが一致する投稿データを取得
-        $post = Article::find($request->id);
-        if (empty($post)) {
-            abort(404);
-        }
-        return view('admin.article.show', ['post' => $post]);
-    }
 }

--- a/app/Http/Controllers/Admin/ProfileController.php
+++ b/app/Http/Controllers/Admin/ProfileController.php
@@ -3,21 +3,21 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
-use Illuminate\Http\Request; // 通常のリクエスト
-// use Illuminate\Foundation\Auth\User; // AuthのUserモデル(以前の記述)
-// use Illuminate\Foundation\Auth\RegistersUsers; // 追加(使用していないので無効にする)
-use App\User; // Userモデル(こっちを使う)
+use Illuminate\Http\Request;
+
+use App\User; // Userモデルを使う
 use Illuminate\Support\Facades\Auth; // Authファサードを使う
 use Intervention\Image\Facades\Image; // InterventionImageを使う(画像リサイズ)
-use Illuminate\Support\Facades\Storage; // Storageファサードを使う
+use Illuminate\Support\Facades\Storage; // Storageファサードを使う(ユーザー画像を保存)
 
 class ProfileController extends Controller
 {
     // editアクション
-    public function edit(Request $request)
+    public function edit()
     {
-        // Modelからデータを取得する(idで検索)
-        $user_data = User::find($request->id);
+        // Modelからデータを取得する(ログインユーザーのidで検索)
+        $user_data = User::find(Auth::user()->id);
+
         return view('admin.profile.edit', ['user_data' => $user_data]);
     }
 
@@ -46,7 +46,7 @@ class ProfileController extends Controller
 
             // 加工した画像からhashを生成し、ファイル名を設定する
             $image_hash = md5($resized_image->__toString());
-            $image_name = "{$image_hash}.jpg"; // TODO:$image_nameという変数は無くせるのでは？
+            $image_name = "{$image_hash}.jpg"; // todo:「$image_name」という変数は無くせないか？
             $user_data->user_image_path = $image_name; // user_image_pathカラムに書き込む
 
             // 加工した画像を保存する
@@ -74,7 +74,7 @@ class ProfileController extends Controller
     }
 
     // indexアクション
-    public function index(Request $request)
+    public function index()
     {
         // Userモデルから全データを取り出してViewに渡す
         $users = User::all();

--- a/resources/views/admin/article/edit.blade.php
+++ b/resources/views/admin/article/edit.blade.php
@@ -14,6 +14,7 @@
         みんなのプロフィール一覧
     </a>
 </li>
+@endsection
 
 {{-- ここからコンテンツ --}}
 @section('content')

--- a/resources/views/admin/article/index.blade.php
+++ b/resources/views/admin/article/index.blade.php
@@ -66,16 +66,20 @@
             @foreach ($articles as $post)
             <div class="card post-list">
                 <div class="card-header bg-dark text-white py-1">
+                    @isset($post->user_image_path)
                     <img class="float-left prof-image" src="{{ '/storage/user_image/' . $post->user_image_path }}">
+                    @else
+                    <img class="float-left prof-image" src="{{ '/storage/user_image/defaulte_user.jpg' }}">
+                    @endisset
                     <span class="float-left pl-2 pt-3">
-                        {{ $post->user_name }} (id：{{ $post->user_id }})
+                        {{ $post->user_name }}
                     </span>
                     <span class="float-right pt-3">
                         {{ $post->created_at->format('Y年m月d日 H:i') }}
                     </span>
                 </div>
 
-                <a class="card-body pt-1 pb-1" href="{{ action('Admin\ArticleController@show', ['id' => $post->id]) }}"
+                <a class="card-body pt-1 pb-1" href="{{ action('Admin\CommentController@show', ['id' => $post->id]) }}"
                     style="text-decoration: none;">
                     <div class="card-text text-dark pt-2 pb-2">
                         {!! nl2br(e($post->body)) !!}
@@ -86,7 +90,7 @@
                         {{-- <img src="{{ asset('image/' . $post->image_path) }}" > --}}
                         @endisset
                     </div>
-                    <div class="card-text">
+                    <div class="card-text text-dark">
                         @isset($post->edited_at)
                         <div class="float-right">
                             <br>
@@ -97,13 +101,9 @@
                 </a>
 
                 <div class="card-footer bg-white py-1">
-                    <a class="badge badge-secondary"
-                        href="{{ action('Admin\ArticleController@show', ['id' => $post->id]) }}">
-                        コメント {{ $post->comments->count() }}件
-                    </a>
                     <a class="badge badge-primary"
-                        href="{{ action('Admin\ArticleController@show', ['id' => $post->id]) }}">
-                        コメントを追加する
+                        href="{{ action('Admin\CommentController@show', ['id' => $post->id]) }}">
+                        コメント {{ $post->comments->count() }}件
                     </a>
 
                     {{-- ログインユーザーと一致する場合または管理ユーザーの場合は編集削除可能 --}}

--- a/resources/views/admin/comment/edit.blade.php
+++ b/resources/views/admin/comment/edit.blade.php
@@ -14,6 +14,7 @@
         みんなのプロフィール一覧
     </a>
 </li>
+@endsection
 
 {{-- ここからコンテンツ --}}
 @section('content')

--- a/resources/views/admin/comment/show.blade.php
+++ b/resources/views/admin/comment/show.blade.php
@@ -29,9 +29,13 @@
             <a href="{{ action('Admin\ArticleController@index') }}">← 投稿一覧に戻る</a>
             <div class="card">
                 <div class="card-header bg-dark text-white">
+                    @isset($post->user_image_path)
                     <img class="float-left prof-image" src="{{ '/storage/user_image/' . $post->user_image_path }}">
+                    @else
+                    <img class="float-left prof-image" src="{{ '/storage/user_image/defaulte_user.jpg' }}">
+                    @endisset
                     <span class="float-left pl-2 pt-3">
-                        {{ $post->user_name }} (id：{{ $post->user_id }})
+                        {{ $post->user_name }}
                     </span>
                     <span class="float-right pt-3">
                         {{ $post->created_at->format('Y年m月d日 H:i') }}
@@ -85,9 +89,13 @@
             @foreach ($post->comments as $comment)
             <div class="card comment-list">
                 <div class="card-header bg-secondary text-white py-2">
+                    @isset($comment->user_image_path)
                     <img class="float-left prof-image" src="{{ '/storage/user_image/' . $comment->user_image_path }}">
+                    @else
+                    <img class="float-left prof-image" src="{{ '/storage/user_image/defaulte_user.jpg' }}">
+                    @endisset
                     <span class="float-left pl-2 pt-3">
-                        {{ $comment->user_name }} (id：{{ $comment->user_id }})
+                        {{ $comment->user_name }}
                     </span>
                     <span class="float-right pt-3">
                         {{ $comment->created_at->format('Y年m月d日 H:i') }}
@@ -98,12 +106,15 @@
                         {!! nl2br(e($comment->body)) !!}
                     </div>
                 </div>
+                {{-- ログインユーザーと一致する場合または管理ユーザーの場合は編集削除可能 --}}
+                @if ($comment->user_id == auth::user()->id || auth::user()->id == 1)
                 <div class="card-footer bg-white py-1">
                     <div class="card-link float-right">
                         <a href="{{ action('Admin\CommentController@edit', ['id' => $comment->id]) }}">編集する</a>
                         <a href="{{ action('Admin\CommentController@delete', ['id' => $comment->id]) }}">削除する</a>
                     </div>
                 </div>
+                @endif
             </div>
             @endforeach
         </div>

--- a/resources/views/admin/profile/edit.blade.php
+++ b/resources/views/admin/profile/edit.blade.php
@@ -34,7 +34,7 @@
                 <div class="form-group row">
                     <label class="col-md-2" for="name">ユーザー名</label>
                     <div class="col-md-9">
-                        <input type="text" class="form-control" name="name" value="{{ $user_data->name }}">
+                        <input type="text" class="form-control" name="name" value="{{ optional($user_data)->name }}">
                     </div>
                 </div>
                 <br>
@@ -49,7 +49,7 @@
                     <label class="col-md-2" for="introduction">プロフィール</label>
                     <div class="col-md-9">
                         <textarea class="form-control" name="introduction" cols="30"
-                            rows="6">{{ $user_data->introduction }}</textarea>
+                            rows="6">{{ optional($user_data)->introduction }}</textarea>
                     </div>
                 </div>
 
@@ -59,7 +59,7 @@
                     <div class="col-md-10">
                         <input type="file" class="form-control-file" name="image">
                         <div class="form-text text-info">
-                            設定中の画像ファイル： {{ $user_data->user_image_path }}
+                            設定中の画像ファイル： {{ optional($user_data)->user_image_path }}
                         </div>
                         <div class="form-check">
                             <label class="form-check-label">
@@ -72,7 +72,7 @@
                 {{-- 更新ボタン --}}
                 <div class="form-group row">
                     <div class="col-md-4 offset-md-2">
-                        <input type="hidden" name="id" value="{{ $user_data->id }}">
+                        <input type="hidden" name="id" value="{{ optional($user_data)->id }}">
                         {{ csrf_field() }}
                         <input type="submit" class="btn btn-primary" value="更新">
                     </div>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -65,7 +65,11 @@
                             <a id="navbarDropdown" class="nav-link dropdown-toggle" href="#" role="button"
                                 data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" v-pre>
                                 <span>{{ Auth::user()->name }}</span>
+                                @isset(Auth::user()->user_image_path)
                                 <img src="{{ '/storage/user_image/' . Auth::user()->user_image_path }}">
+                                @else
+                                <img src="{{ '/storage/user_image/defaulte_user.jpg' }}">
+                                @endisset
                             </a>
 
                             {{-- プロフィール編集 --}}

--- a/routes/web.php
+++ b/routes/web.php
@@ -25,11 +25,10 @@ Route::group(['prefix' => 'admin', 'middleware' => 'auth'], function () {
     Route::get('article/edit', 'Admin\ArticleController@edit');
     Route::post('article/edit', 'Admin\ArticleController@update');
     Route::get('article/delete', 'Admin\ArticleController@delete');
-
-    Route::get('article/show', 'Admin\ArticleController@show');
     Route::get('articles', 'Admin\ArticleController@index');
 
-    Route::post('article/show', 'Admin\CommentController@create');
+    Route::get('comment/show', 'Admin\CommentController@show');
+    Route::post('comment/show', 'Admin\CommentController@create');
     Route::get('comment/edit', 'Admin\CommentController@edit');
     Route::post('comment/edit', 'Admin\CommentController@update');
     Route::get('comment/delete', 'Admin\CommentController@delete');


### PR DESCRIPTION
・投稿やコメントのプロフィール画像やユーザー名を、投稿ユーザーのidでUserモデルから検索するように変更した。
・commentsテーブルにuser_image_pathが無かったので追加。
・user_image_pathのカラムを追加し、user_nameとともにShowアクションで毎回上書きされるロジックにした。
・その他、image_pathがセットされていなければデフォルト画像を表示するようにした。