### PR TITLE
 #51 画像のファイル削除機能実装や投稿のユーザー情報取得のロジックを修正

### DIFF
--- a/app/Http/Controllers/Admin/CommentController.php
+++ b/app/Http/Controllers/Admin/CommentController.php
@@ -23,7 +23,7 @@ class CommentController extends Controller
 
         // ログインユーザー情報と投稿idを代入する
         $comments->user_id = Auth::user()->id;
-        $comments->user_name = Auth::user()->name; // defaulte値として必要なのでこれは残しておく(nullableでない)
+        $comments->user_name = Auth::user()->name; // defaulte値として必要なのでnameは残しておく(nullableでない)
 
         // $comments->user_image_path = Auth::user()->user_image_path; // commentテーブルにuser画像カラムは無い！
         // そもそも投稿にはuser_idさえ持たせれば、表示する時にuser_idでUserモデルから最新の名前や画像を検索できる？
@@ -65,7 +65,7 @@ class CommentController extends Controller
         // 編集日時を追加する
         $comments->edited_at = Carbon::now();
 
-        // データを上書きして保存する
+        // フォームにデータを上書きして保存する
         $comments->fill($comment_form)->save();
 
         return redirect('admin/articles');
@@ -94,8 +94,6 @@ class CommentController extends Controller
             $comment->user_name = User::find($comment->user_id)->name;
             $comment->user_image_path = User::find($comment->user_id)->user_image_path;
         }
-
-        // ここに保存の処理が必要？フォームではないから不要？？
 
         // Viewに投稿データを渡す
         return view('admin.comment.show', ['post' => $post]);

--- a/resources/views/admin/article/index.blade.php
+++ b/resources/views/admin/article/index.blade.php
@@ -18,11 +18,10 @@
 
 {{-- ここからコンテンツ --}}
 @section('content')
-<div class="container">
-    <div class="row">
-        <h2 class="h3 m-2">みんなの投稿</h2>
-    </div>
-
+<div class="container mt-4">
+    {{-- <div class="row">
+        <h2 class="h3 m-4">みんなの投稿</h2>
+    </div> --}}
     <div class="row">
         {{-- 投稿作成ボタン --}}
         <div class="col-md-3 offset-1">

--- a/resources/views/admin/profile/index.blade.php
+++ b/resources/views/admin/profile/index.blade.php
@@ -33,7 +33,7 @@
                     @isset($user->user_image_path)
                     <img class="prof-image float-left" src="{{ '/storage/user_image/' . $user->user_image_path }}">
                     @else
-                    <img class="prof-image float-left" src="{{ '/storage/user_image/' . $user->user_image_path }}">
+                    <img class="prof-image float-left" src="{{ '/storage/user_image/defaulte_user.jpg' }}">
                     @endisset
                     <span class="float-left pl-2 pt-3">
                         名前：{{ $user->name }}


### PR DESCRIPTION
・現状はモデルのimage_pathカラムをnullにするだけのロジックになっていたので、
Storageファサードを使って画像を削除するようにロジックを変更した。
・その他、投稿のユーザー情報取得のロジックを修正した。