### PR TITLE
 #54 AuthのredirectToを修正

### DIFF
--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -14,10 +14,9 @@ class Authenticate extends Middleware
      */
     protected function redirectTo($request)
     {
-        if (! $request->expectsJson()) {
+        if (!$request->expectsJson()) {
             // return route('login'); // 元の記述
-            // return route('top'); // topに変更
-            return route('/'); // "/"にさらに変更
+            return route('top.page'); // 変更
         }
     }
 }


### PR DESCRIPTION
・現状はトップページで「新規登録」以外のページ遷移がうまくいっていない。
・MiddlewareのAuthenticate.phpのRedirectToが「"/"」になっていたので、
　先にWeb.phpで設定したname「"top.page"」に修正した。