### PR TITLE
 #64 プロフィール編集のバグを修正した

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -75,7 +75,8 @@
 
                             {{-- プロフィール編集 --}}
                             <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-                                <a class="dropdown-item" href="{{ url('/admin/profile/edit') }}">プロフィール編集</a>
+                                <a class="dropdown-item"
+                                    href="{{ action('Admin\ProfileController@edit', ['id' => Auth::user()->id]) }}">プロフィール編集</a>
                                 <a class="dropdown-item" href="{{ route('logout') }}"
                                     onclick="event.preventDefault();document.getElementById('logout-form').submit()">
                                     {{ __('Logout') }}


### PR DESCRIPTION
・ナビゲーションバーのプロフィール編集をクリックすると、
　元のデータが取得できないバグが発生していたのでこれを修正した。
・View(app.blade.php)においてナビゲーションバーが単純なurlリンクになっていたことが要因。
　Auth::user()->idでリクエストにuser_idを渡すように変更した。
　以前はController側でAuth::user()で取得していたので問題にならなかったが、
　requestのuser_idでモデルから検索するロジックに変えたのでうまくいかなくなっていた。