### PR TITLE
 #72 信用するプロキシの設定を追加

### DIFF
--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -12,12 +12,12 @@ class TrustProxies extends Middleware
      *
      * @var array|string|null
      */
-    protected $proxies;
+    protected $proxies = '*'; // 公式docよりELBの場合はIPアドレスが分からないため*を使う
 
     /**
      * The headers that should be used to detect proxies.
      *
      * @var int
      */
-    protected $headers = Request::HEADER_X_FORWARDED_ALL;
+    protected $headers = Request::HEADER_X_FORWARDED_AWS_ELB; // 公式docより
 }


### PR DESCRIPTION
httpsでの通信を正常化するために、
TrustProxies.phpにELBを使用した場合のプロキシ設定を追加(公式ドキュメント参照)